### PR TITLE
add feature fabricDefault

### DIFF
--- a/src/main/java/com/webank/wecross/account/ChainAccountDetails.java
+++ b/src/main/java/com/webank/wecross/account/ChainAccountDetails.java
@@ -13,6 +13,7 @@ public class ChainAccountDetails {
     private String type;
 
     private Boolean isDefault;
+    private String fabricDefault;
 
     private String pubKey;
     private String secKey;
@@ -27,6 +28,7 @@ public class ChainAccountDetails {
         properties.put("keyID", keyID);
         properties.put("type", type);
         properties.put("isDefault", isDefault);
+        properties.put("fabricDefault", fabricDefault);
         properties.put("pubKey", pubKey);
         properties.put("secKey", secKey);
         properties.put("ext0", ext0);
@@ -89,6 +91,16 @@ public class ChainAccountDetails {
     @JsonSetter("isDefault")
     public void setIsDefault(Boolean aDefault) {
         isDefault = aDefault;
+    }
+
+    @JsonGetter("fabricDefault")
+    public String getFabricDefault(){
+        return fabricDefault;
+    }
+
+    @JsonSetter("fabricDefault")
+    public void setFabricDefault(String chainName){
+        fabricDefault = chainName;
     }
 
     public String getPubKey() {

--- a/src/main/java/com/webank/wecross/account/UniversalAccount.java
+++ b/src/main/java/com/webank/wecross/account/UniversalAccount.java
@@ -9,6 +9,10 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.ObjectUtils.Null;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +34,52 @@ public class UniversalAccount {
     private Map<String, Map<Integer, Account>> type2ChainAccounts = new HashMap<>();
 
     private Map<String, Account> type2DefaultAccount = new HashMap<>();
+
+    // make every fabric chain has a default account
+    private Map<String,Account> chain2DefaultFabricAccount = new HashMap<>();
+
+    // chain name is like "payment.fabric-mychannel"
+    public Account getFabricAccount(String chainName){
+        return chain2DefaultFabricAccount.get(chainName);
+    }
+
+    // chain name is like "payment.fabric-mychannel"
+    public void setDefaultFabricAccount(String chainName,Account account){
+        chain2DefaultFabricAccount.put(chainName, account);
+        logger.info("setDefaultFabricAccount {} {}", chainName, account);
+    }
+
+    // this func should be added to utils
+    public static boolean isFabricType(String type){
+        return type.contains("Fabric");
+    }
+
+    // this func should be added to utils
+    public static boolean checkChainName(String chainName){
+        if (chainName.length()==0){
+            return false;
+        }
+        String regex="[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+"; 
+        Pattern p=Pattern.compile(regex);
+        Matcher m=p.matcher(chainName);
+        if(m.matches()){
+            return true;
+        }else{
+            return false;
+        }
+    }
+
+    // only use in asyncSendTransaction, asyncCall. maybe asyncCustomCommand can use too.
+    // if not set default fabric chain account, use the universal default fabric account.
+    public Account getSendAccount(String type,String chainName){
+        if (isFabricType(type)){
+            Account account = getFabricAccount(chainName);
+            if (account!=null){
+                return account;
+            }
+        }
+        return getAccount(type);
+    }
 
     public Account getAccount(String type) {
         return type2DefaultAccount.get(type);

--- a/src/main/java/com/webank/wecross/account/UniversalAccountFactory.java
+++ b/src/main/java/com/webank/wecross/account/UniversalAccountFactory.java
@@ -53,6 +53,9 @@ public class UniversalAccountFactory {
                 if (details.getIsDefault().booleanValue()) {
                     ua.setDefaultAccount(type, account);
                 }
+                if (UniversalAccount.isFabricType(type)&&UniversalAccount.checkChainName(details.getFabricDefault())){
+                    ua.setDefaultFabricAccount(details.getFabricDefault(), account);
+                }
             }
         }
 

--- a/src/main/java/com/webank/wecross/config/AuthFilterConfig.java
+++ b/src/main/java/com/webank/wecross/config/AuthFilterConfig.java
@@ -27,6 +27,7 @@ public class AuthFilterConfig {
         remoteAuthFilter.registerAuthUri("/auth/addChainAccount");
         remoteAuthFilter.registerAuthUri("/auth/removeChainAccount");
         remoteAuthFilter.registerAuthUri("/auth/setDefaultAccount");
+        remoteAuthFilter.registerAuthUri("/auth/setDefaultFabricAccount");
         remoteAuthFilter.registerAuthUri("/auth/listAccount");
         remoteAuthFilter.registerAuthUri("/auth/authCode");
         remoteAuthFilter.registerAuthUri("/auth/pub");

--- a/src/main/java/com/webank/wecross/resource/Resource.java
+++ b/src/main/java/com/webank/wecross/resource/Resource.java
@@ -87,7 +87,9 @@ public class Resource {
             return;
         }
 
-        Account account = ua.getAccount(stubType);
+        // Account account = ua.getAccount(stubType);
+        Account account = ua.getSendAccount(stubType, path.toChainName());
+        logger.info("asynCall use account by key: {}, path: {}", account.getKeyID(),this.path);
         TransactionContext context =
                 new TransactionContext(account, this.path, this.resourceInfo, this.blockManager);
         boolean isRawTransaction =
@@ -134,7 +136,9 @@ public class Resource {
             return;
         }
 
-        Account account = ua.getAccount(stubType);
+        // Account account = ua.getAccount(stubType);
+        Account account = ua.getSendAccount(stubType, path.toChainName());
+        logger.info("asynSendTransaction use account by key: {}, path: {}", account.getKeyID(),this.path);
         TransactionContext context =
                 new TransactionContext(account, this.path, this.resourceInfo, this.blockManager);
         boolean isRawTransaction =

--- a/src/main/java/com/webank/wecross/stub/Path.java
+++ b/src/main/java/com/webank/wecross/stub/Path.java
@@ -96,6 +96,16 @@ public class Path {
         }
     }
 
+    // compact zone and chain as ChainName
+    public String toChainName(){
+        return zone + "." + chain;
+    }
+
+    //whether in chain
+    public boolean isInChain(String chainName){
+        return chainName.equals(toChainName());
+    }
+
     public String toURI() {
         if (Objects.nonNull(resource)) {
             return zone + "/" + chain + "/" + resource;

--- a/src/test/java/com/webank/wecross/test/account/CheckChainNameTest.java
+++ b/src/test/java/com/webank/wecross/test/account/CheckChainNameTest.java
@@ -1,0 +1,18 @@
+package com.webank.wecross.test.account;
+
+import  com.webank.wecross.account.UniversalAccount;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CheckChainNameTest {
+    @Test
+    public void isCheckRight() throws Exception {
+        Assert.assertTrue(UniversalAccount.checkChainName("") == false);
+        Assert.assertTrue(UniversalAccount.checkChainName("chainName") == false);
+        Assert.assertTrue(UniversalAccount.checkChainName("payment.fabric") == true);
+        Assert.assertTrue(UniversalAccount.checkChainName("payment.fabric-mychannel") == true);
+        Assert.assertTrue(UniversalAccount.checkChainName("payment.bcos-group1") == true);
+        Assert.assertTrue(UniversalAccount.checkChainName("payment.bcos-group2.helloworld") == false);
+        Assert.assertTrue(UniversalAccount.checkChainName("testbcos-group2") == false);
+    }
+}


### PR DESCRIPTION
---
name: Default template
about: Default template for pull request
title: '<feat>(transaction): simplify sending transactions when cross fabric chains'
---
## feature_fabricDefault
在涉及多个fabric链时，需要频繁切换Fabric的默认账户。需要一种方案来解决该问题。

## 方案讨论
### WeCross-Console本地管理
最理想的情况是在WeCross-Console端建立一个本地的default映射，在调用sendTransaction时将对应的默认账号ID附上。遗憾的是WeCross在执行sendTransaction时是向WeCross-Account-Manager请求的默认账号用于发送交易信息，采用该方案需要修改整套WeCross方案。
### 使用数据库管理fabricDefault数据
该方案是在WeCross-Account-Manager数据库中建立一新的对象fabricDefault，如管理ChainAccount一般管理，因为现在的逻辑是WeCross-Account-Manager每次取UA时会在数据库中遍历寻找它关联的ChainAccount，那么也可以在取UA时遍历寻找它相关的fabricDefault。

该方案的好处是较为安全对现有代码逻辑几乎没有影响，但是需要重新构造一整个fabricDefault的运作方式并附加到UA的维护中，故也没有采用。

### ChainAccount增加fabricDefault属性
在现有的ChainAccount基础上，增加一fabricDefault属性，指明该ChainAccount是哪一个fabric链的默认账户，如果不是默认账户则该项置空。该方案实现简单同时符合现在的WeCross与WeCross-Account-Manager的运作逻辑。选取该方案。

## 实现
在<font color='red'>WeCross-Console</font>中增加setDefaultFabricAccount指令，命令使用方法如下：

	setDefaultFabricAccount payment.fabric-mychannel 1
其中payment.fabric-mychannel为chainName，1为账户的keyID。仿照setDefaultAccount写底层逻辑，在<font color='red'>WeCross-Java-SDK</font>中增加setDefaultFabricAccount的调用函数，以及修改listAccount的打印方式来显示fabric账户的fabricDefault属性。

在<font color='red'>WeCross</font>中增加/auth/setDefaultFabricAccount的路由，同时修改UA的构造方法，更改asynSendTransaction和asynCall中获取默认账户的方法。

在<font color='red'>WeCross-Account-Manager</font>中为ChainAccount增加fabricDefault属性，修改相应的对象构造方法以及数据库更新方法。

## Consideration
由于修改了fabric链的sendTransaction与call的默认账户获取方式，不知道对WeCrossHub、HTLC、XA相关有没有影响（目测感觉没有）。

## Future
* customcommand中如fabric资源部署实例化相关应该也适用，可以简化fabric的资源部署过程。

## Want
需要WeCross的跨多条Fabric链的一键部署脚本，否则开发测试过于困难。

## Test
### 在没有找到fabricDefault时使用当前默认Fabric账号发送交易
```
>> login
>> setDefaultAccount Fabric1.4 2
Result: success
Universal Account info has been changed, now auto-login again.
Result: success
=============================================================================================
Universal Account:
username: org1-admin
pubKey  : 3059301306...
uaID    : 3059301306...
>> listAccount
Universal Account:
username: org1-admin
pubKey  : 3059301306...
uaID    : 3059301306...
chainAccounts: [
	BCOS2.0 Account:
	keyID    : 0
	type     : BCOS2.0
	address  : 0x6f0674e82089a1e1ce147597a02d19878e18e59a
	isDefault: true
	----------
	GM_BCOS2.0 Account:
	keyID    : 4
	type     : GM_BCOS2.0
	address  : 0xda786dcc436164fa1d0a114c01786e74c8ec999f
	isDefault: true
	----------
	Fabric1.4 Account:
	keyID    : 2
	type     : Fabric1.4
	MembershipID : Org2MSP
	isDefault: true
	fabricDefault: 
	----------
	Fabric1.4 Account:
	keyID    : 3
	type     : Fabric1.4
	MembershipID : Org1MSP
	isDefault: false
	fabricDefault: 
	----------
	Fabric1.4 Account:
	keyID    : 1
	type     : Fabric1.4
	MembershipID : Org1MSP
	isDefault: false
	fabricDefault: 
	----------
]
>> sendTransaction payment.fabric-mychannel.sacc set a 666
Txhash  : 5ad6b31e1e372808c3de4d677b5919623b540800c3e31656ff0c70c2801055df
BlockNum: 6
Result  : [666]
```
验证到当chainName没有设置fabricDefault时，sendTransaction将采用当前默认的Fabric账户进行交易发送。

### 设置fabricDefault并通过fabricDefault进行交易发送
```
>> login
>> setDefaultAccount Fabric1.4 1
>> setDefaultFabricAccount payment.fabric-mychannel 2
>> listAccount
Universal Account:
username: org1-admin
pubKey  : 3059301306...
uaID    : 3059301306...
chainAccounts: [
	BCOS2.0 Account:
	keyID    : 0
	type     : BCOS2.0
	address  : 0x6f0674e82089a1e1ce147597a02d19878e18e59a
	isDefault: true
	----------
	GM_BCOS2.0 Account:
	keyID    : 4
	type     : GM_BCOS2.0
	address  : 0xda786dcc436164fa1d0a114c01786e74c8ec999f
	isDefault: true
	----------
	Fabric1.4 Account:
	keyID    : 1
	type     : Fabric1.4
	MembershipID : Org1MSP
	isDefault: true
	fabricDefault: 
	----------
	Fabric1.4 Account:
	keyID    : 3
	type     : Fabric1.4
	MembershipID : Org1MSP
	isDefault: false
	fabricDefault: 
	----------
	Fabric1.4 Account:
	keyID    : 2
	type     : Fabric1.4
	MembershipID : Org2MSP
	isDefault: false
	fabricDefault: payment.fabric-mychannel
	----------
]
>> sendTransaction payment.fabric-mychannel.sacc set b 777
Txhash  : 7c49ce50cde534d6c4bcd193f394246c42c7ce4d19fefd85c808299d04e0676c
BlockNum: 7
Result  : [777]
>> call payment.fabric-mychannel.sacc get a
Result  : [666]
```
查阅Router 127.0.0.1-8250-25500的日志（我在WeCross中增加了相应的loginfo便于debug）得： 
* 2022-05-26 16:16:26.155 [http-callback4] INFO  Response() - asynSendTransaction use account by key: 2, path: payment.fabric-mychannel.sacc
* 2022-05-26 16:16:37.320 [http-callback5] INFO  Response() - asynCall use account by key: 2, path: payment.fabric-mychannel.sacc

说明此时确实是使用的keyID为2的Fabric账户进行的sendTransaction,同理call也是正常的。

### 设置已有的fabricDefault
```
>> login
>> listAccount
Universal Account:
username: org1-admin
pubKey  : 3059301306...
uaID    : 3059301306...
chainAccounts: [
	BCOS2.0 Account:
	keyID    : 0
	type     : BCOS2.0
	address  : 0xacbf658f8f89a0a45b08949cf6f91c94c815e867
	isDefault: true
	----------
	GM_BCOS2.0 Account:
	keyID    : 4
	type     : GM_BCOS2.0
	address  : 0x11cb6c74251f4eb60cf4c6fc0db820a3997cdf35
	isDefault: true
	----------
	Fabric1.4 Account:
	keyID    : 1
	type     : Fabric1.4
	MembershipID : Org1MSP
	isDefault: true
	fabricDefault: 
	----------
	Fabric1.4 Account:
	keyID    : 3
	type     : Fabric1.4
	MembershipID : Org1MSP
	isDefault: false
	fabricDefault: 
	----------
	Fabric1.4 Account:
	keyID    : 2
	type     : Fabric1.4
	MembershipID : Org2MSP
	isDefault: false
	fabricDefault: payment.fabric-mychannel
	----------
]
>> setDefaultFabricAccount payment.fabric-mychannel 1
>> listAccount
Universal Account:
username: org1-admin
pubKey  : 3059301306...
uaID    : 3059301306...
chainAccounts: [
	BCOS2.0 Account:
	keyID    : 0
	type     : BCOS2.0
	address  : 0xacbf658f8f89a0a45b08949cf6f91c94c815e867
	isDefault: true
	----------
	GM_BCOS2.0 Account:
	keyID    : 4
	type     : GM_BCOS2.0
	address  : 0x11cb6c74251f4eb60cf4c6fc0db820a3997cdf35
	isDefault: true
	----------
	Fabric1.4 Account:
	keyID    : 1
	type     : Fabric1.4
	MembershipID : Org1MSP
	isDefault: true
	fabricDefault: payment.fabric-mychannel
	----------
	Fabric1.4 Account:
	keyID    : 3
	type     : Fabric1.4
	MembershipID : Org1MSP
	isDefault: false
	fabricDefault: 
	----------
	Fabric1.4 Account:
	keyID    : 2
	type     : Fabric1.4
	MembershipID : Org2MSP
	isDefault: false
	fabricDefault: 
	----------
]
```

可以看到在设置keyID为1的账户的fabricDefault时，keyID为2的账户的fabricDefault刷掉，始终保持唯一性。



